### PR TITLE
add lib path to eager_load_paths instead of autoload_paths

### DIFF
--- a/lib/jquery/passroids/rails.rb
+++ b/lib/jquery/passroids/rails.rb
@@ -4,7 +4,7 @@ module Jquery
   module Passroids
     module Rails
       class Engine < ::Rails::Engine
-        config.autoload_paths << "#{self.root}/lib"
+        config.eager_load_paths << "#{self.root}/lib"
       end
     end
   end


### PR DESCRIPTION
@smoriwaki 

以下のようにしましたが、期待通りに動きませんでした。

```
config.paths.add "#{self.root}/lib", autoload: true
```

`eager_load_paths` にパスを追加するとうまく動きましたので、こちらで対応しております。
